### PR TITLE
fix: update article date to July 27, 2025

### DIFF
--- a/blog/posts/create-mcp-server/article.md
+++ b/blog/posts/create-mcp-server/article.md
@@ -8,7 +8,7 @@ tags:
   - LLM
 author: "@jondotsoy"
 lang: es-CL
-date: 2025-01-27
+date: 2025-07-27
 summary: "Aprende a crear tu propio servidor MCP (Model Context Protocol) usando TypeScript SDK para conectar aplicaciones de IA con datos y funcionalidades externas de forma estandarizada y segura."
 ---
 


### PR DESCRIPTION
This pull request includes a minor update to the metadata of the `blog/posts/create-mcp-server/article.md` file. The publication date has been changed to a later date.

* Metadata update:
  * [`blog/posts/create-mcp-server/article.md`](diffhunk://#diff-a900548cf0b91a6db10d52671664e4c6fc8e04b5a5f27fd04d01cae8b392cf35L11-R11): Updated the `date` field from `2025-01-27` to `2025-07-27`.